### PR TITLE
added functionality

### DIFF
--- a/src/deparser.js
+++ b/src/deparser.js
@@ -1186,6 +1186,18 @@ LANGUAGE '${this.deparse(elems.language.DefElem.arg)}' ${this.deparse(elems.vola
 
     return output.join(' ');
   }
+  ['CreateSchemaStmt'](node) {
+    const output = [];
+
+    output.push('CREATE');
+    if (node.replace) {
+      output.push('OR REPLACE');
+    }
+    output.push('SCHEMA');
+    output.push(node.schemaname);
+    return output.join(' ');
+  }
+
   ['SortBy'](node) {
     const output = [];
 

--- a/src/deparser.js
+++ b/src/deparser.js
@@ -1198,6 +1198,19 @@ LANGUAGE '${this.deparse(elems.language.DefElem.arg)}' ${this.deparse(elems.vola
     return output.join(' ');
   }
 
+  ['TransactionStmt'](node) {
+    switch (node.kind) {
+      case 0:
+        return 'BEGIN';
+        break;
+      case 1:
+        break;
+      case 2:
+        return 'COMMIT';
+      default:
+    }
+  }
+
   ['SortBy'](node) {
     const output = [];
 

--- a/test/fixtures/create/check.sql
+++ b/test/fixtures/create/check.sql
@@ -1,0 +1,17 @@
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric CHECK (price > 0)
+);
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric CONSTRAINT positive_price CHECK (price > 0)
+);
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric CHECK (price > 0),
+    discounted_price numeric CHECK (discounted_price > 0),
+    CHECK (price > discounted_price)
+);

--- a/test/fixtures/create/defaults.sql
+++ b/test/fixtures/create/defaults.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "customer_product_categories" (
+  "id" serial PRIMARY KEY,
+  "name" text NOT NULL,
+  "effective" tstzrange DEFAULT '[-infinity,infinity]'
+)

--- a/test/fixtures/create/exclude.sql
+++ b/test/fixtures/create/exclude.sql
@@ -1,0 +1,10 @@
+CREATE TABLE circles (
+    c circle,
+    EXCLUDE USING gist (c WITH &&)
+);
+CREATE TABLE "customer_product_categories" (
+  "id" serial PRIMARY KEY,
+  "name" text NOT NULL,
+  "effective" tstzrange DEFAULT '[-infinity,infinity]',
+  EXCLUDE USING gist (LOWER("name") WITH =, "effective" WITH &&)
+)

--- a/test/fixtures/create/foreign.sql
+++ b/test/fixtures/create/foreign.sql
@@ -1,0 +1,31 @@
+CREATE TABLE orders (
+    order_id integer PRIMARY KEY,
+    product_no integer REFERENCES products (product_no),
+    quantity integer
+);
+CREATE TABLE orders (
+    order_id integer PRIMARY KEY,
+    product_no integer REFERENCES products,
+    quantity integer
+);
+CREATE TABLE t1 (
+  a integer PRIMARY KEY,
+  b integer,
+  c integer,
+  FOREIGN KEY (b, c) REFERENCES other_table (c1, c2)
+);
+CREATE TABLE products (
+    product_no integer PRIMARY KEY,
+    name text,
+    price numeric
+);
+CREATE TABLE orders (
+    order_id integer PRIMARY KEY,
+    shipping_address text
+);
+CREATE TABLE order_items (
+    product_no integer REFERENCES products,
+    order_id integer REFERENCES orders,
+    quantity integer,
+    PRIMARY KEY (product_no, order_id)
+);

--- a/test/fixtures/create/nulls.sql
+++ b/test/fixtures/create/nulls.sql
@@ -1,0 +1,15 @@
+CREATE TABLE products (
+    product_no integer NOT NULL,
+    name text NOT NULL,
+    price numeric
+);
+CREATE TABLE products (
+    product_no integer NULL,
+    name text NULL,
+    price numeric NULL
+);
+CREATE TABLE products (
+    product_no integer NOT NULL,
+    name text NOT NULL,
+    price numeric NOT NULL CHECK (price > 0)
+);

--- a/test/fixtures/create/on_delete.sql
+++ b/test/fixtures/create/on_delete.sql
@@ -1,0 +1,6 @@
+CREATE TABLE order_items (
+    product_no integer REFERENCES products ON DELETE RESTRICT,
+    order_id integer REFERENCES orders ON DELETE CASCADE,
+    quantity integer,
+    PRIMARY KEY (product_no, order_id)
+);

--- a/test/fixtures/create/on_update.sql
+++ b/test/fixtures/create/on_update.sql
@@ -1,0 +1,6 @@
+CREATE TABLE order_items (
+    product_no integer REFERENCES products ON UPDATE RESTRICT,
+    order_id integer REFERENCES orders ON UPDATE CASCADE,
+    quantity integer,
+    PRIMARY KEY (product_no, order_id)
+);

--- a/test/fixtures/create/unique.sql
+++ b/test/fixtures/create/unique.sql
@@ -1,0 +1,22 @@
+CREATE TABLE products (
+    product_no integer UNIQUE,
+    name text,
+    price numeric
+);
+CREATE TABLE products (
+    product_no integer,
+    name text,
+    price numeric,
+    UNIQUE (product_no)
+);
+CREATE TABLE example (
+    a integer,
+    b integer,
+    c integer,
+    UNIQUE (a, c)
+);
+CREATE TABLE products (
+    product_no integer CONSTRAINT must_be_different UNIQUE,
+    name text,
+    price numeric
+);

--- a/test/fixtures/functions/basic.sql
+++ b/test/fixtures/functions/basic.sql
@@ -9,7 +9,7 @@ WHERE
 $$
 LANGUAGE 'sql' VOLATILE;
 
-CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS SETOF obj.geo
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS obj.geo
 AS $$
 UPDATE
     mytable
@@ -19,40 +19,3 @@ WHERE
     id = some_id
 $$
 LANGUAGE 'sql' VOLATILE;
-
-CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS SETOF obj.geo
-AS $$
-UPDATE
-    mytable
-SET
-    ref_id = new_ref_id
-WHERE
-    id = some_id
-$$
-LANGUAGE 'sql' VOLATILE;
-
-CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS integer
-AS $$
-SELECT * FROM
-    mytable
-$$
-LANGUAGE 'sql' VOLATILE;
-
-CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS TABLE (path text, name integer)
-AS $$
-SELECT * FROM
-    mytable
-$$
-LANGUAGE 'sql' VOLATILE;
-
-CREATE OR REPLACE FUNCTION helpers.some_method ()
-    RETURNS TRIGGER
-AS $$
-BEGIN
-    IF tg_op = 'INSERT' THEN
-        NEW.some_prop = helpers.do_magic (NEW.data);
-        RETURN NEW;
-    END IF;
-END;
-$$
-LANGUAGE 'plpgsql';

--- a/test/fixtures/functions/basic.sql
+++ b/test/fixtures/functions/basic.sql
@@ -1,0 +1,58 @@
+-- CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS void
+-- AS $$
+-- UPDATE
+--     mytable
+-- SET
+--     ref_id = new_ref_id
+-- WHERE
+--     id = some_id
+-- $$
+-- LANGUAGE 'sql' VOLATILE;
+--
+-- CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS SETOF obj.geo
+-- AS $$
+-- UPDATE
+--     mytable
+-- SET
+--     ref_id = new_ref_id
+-- WHERE
+--     id = some_id
+-- $$
+-- LANGUAGE 'sql' VOLATILE;
+--
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS SETOF obj.geo
+AS $$
+UPDATE
+    mytable
+SET
+    ref_id = new_ref_id
+WHERE
+    id = some_id
+$$
+LANGUAGE 'sql' VOLATILE;
+
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS integer
+AS $$
+SELECT * FROM
+    mytable
+$$
+LANGUAGE 'sql' VOLATILE;
+
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS TABLE (path text, name integer)
+AS $$
+SELECT * FROM
+    mytable
+$$
+LANGUAGE 'sql' VOLATILE;
+
+CREATE OR REPLACE FUNCTION helpers.some_method ()
+    RETURNS TRIGGER
+AS $$
+BEGIN
+    IF tg_op = 'INSERT' THEN
+        NEW.some_prop = helpers.do_magic (NEW.data);
+        RETURN NEW;
+    END IF;
+END;
+$$
+LANGUAGE 'plpgsql';

--- a/test/fixtures/functions/basic.sql
+++ b/test/fixtures/functions/basic.sql
@@ -1,25 +1,25 @@
--- CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS void
--- AS $$
--- UPDATE
---     mytable
--- SET
---     ref_id = new_ref_id
--- WHERE
---     id = some_id
--- $$
--- LANGUAGE 'sql' VOLATILE;
---
--- CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS SETOF obj.geo
--- AS $$
--- UPDATE
---     mytable
--- SET
---     ref_id = new_ref_id
--- WHERE
---     id = some_id
--- $$
--- LANGUAGE 'sql' VOLATILE;
---
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS void
+AS $$
+UPDATE
+    mytable
+SET
+    ref_id = new_ref_id
+WHERE
+    id = some_id
+$$
+LANGUAGE 'sql' VOLATILE;
+
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS SETOF obj.geo
+AS $$
+UPDATE
+    mytable
+SET
+    ref_id = new_ref_id
+WHERE
+    id = some_id
+$$
+LANGUAGE 'sql' VOLATILE;
+
 CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS SETOF obj.geo
 AS $$
 UPDATE

--- a/test/fixtures/functions/returns_table.sql
+++ b/test/fixtures/functions/returns_table.sql
@@ -1,0 +1,6 @@
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS TABLE (path text, name integer)
+AS $$
+SELECT * FROM
+    mytable
+$$
+LANGUAGE 'sql' VOLATILE;

--- a/test/fixtures/functions/returns_trigger.sql
+++ b/test/fixtures/functions/returns_trigger.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION helpers.some_method ()
+    RETURNS TRIGGER
+AS $$
+BEGIN
+    IF tg_op = 'INSERT' THEN
+        NEW.some_prop = helpers.do_magic (NEW.data);
+        RETURN NEW;
+    END IF;
+END;
+$$
+LANGUAGE 'plpgsql';

--- a/test/fixtures/functions/setof.sql
+++ b/test/fixtures/functions/setof.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id uuid, other_id uuid) RETURNS SETOF obj.geo
+AS $$
+UPDATE
+    mytable
+SET
+    ref_id = new_ref_id
+WHERE
+    id = some_id
+$$
+LANGUAGE 'sql' VOLATILE;
+
+CREATE OR REPLACE FUNCTION someschema.myfunc (some_id obj.geo_type, other_id obj.geo_type) RETURNS SETOF obj.geo
+AS $$
+UPDATE
+    mytable
+SET
+    ref_id = new_ref_id
+WHERE
+    id = some_id
+$$
+LANGUAGE 'sql' VOLATILE;

--- a/test/fixtures/transactions/begin_commit.sql
+++ b/test/fixtures/transactions/begin_commit.sql
@@ -1,0 +1,6 @@
+BEGIN;
+CREATE TABLE products (
+    product_no integer,
+    name text
+);
+COMMIT;

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,31 @@
 import chai from 'chai';
 import fs from 'fs';
-import glob from 'glob';
+import { sync as glob } from 'glob';
 
 chai.should();
 
 import { deparse, parse, clean, byType } from '../src';
 
+const supportedStatements = [
+  'SelectStmt'
+  // 'CreateFunctionStmt',
+  // 'CreateStmt',
+  // 'TransactionStmt'
+];
+
+const isSupported = node => {
+  for (var i = 0; i < supportedStatements.length; i++) {
+    if (node[supportedStatements[i]] != null) return true;
+  }
+};
+
 const pattern = process.env.FILTER ? `*${process.env.FILTER}*.sql` : '*.sql';
 
-let files = glob.sync(`./test/fixtures/${pattern}`);
-files = files.concat(glob.sync(`./test/fixtures/upstream/${pattern}`));
+let files = glob(`./test/fixtures/${pattern}`)
+  .concat(glob(`./test/fixtures/create/${pattern}`))
+  .concat(glob(`./test/fixtures/functions/${pattern}`))
+  .concat(glob(`./test/fixtures/tranactions/${pattern}`))
+  .concat(glob(`./test/fixtures/upstream/${pattern}`));
 
 const log = (msg) => {
   fs.writeSync(1, `${msg}\n`);


### PR DESCRIPTION
It’s not complete, but has a lot more functionality than before. I implemented

```
CreateStmt
ConstraintStmt
Constraint
ReferenceConstraint
ExclusionConstraint
FunctionParameter
CreateFunctionStmt
CreateSchemaStmt
TransactionStmt
```

On a high level you can now
* create basic functions that return types, returns table, returns trigger, and setoff. 
* create tables with check, defaults, exclude, foreign key, nulls, unique constraints, including basic on delete, on update

Limitations 
* ON UPDATE and ON DELETE only have RESTRICT and CASCADE (should be easy to add more)
* TransactionStmt is limited to BEGIN and COMMIT (needs ROLLBACK, etc)
* Although the cases I tested work (even passing `check()` in `test.js`), there are some tests not passing from the upstream. I think we need to implement a few more items like TEMP tables, INHERITS, etc., for those to pass. 

this could possibly help close https://github.com/zhm/pg-query-parser/issues/8